### PR TITLE
Change serialization to exclude missing fields

### DIFF
--- a/marshmallow_objects/models.py
+++ b/marshmallow_objects/models.py
@@ -22,6 +22,9 @@ MM2 = marshmallow.__version__.startswith('2')
 
 @marshmallow.post_load
 def __make_object__(self, data):
+    for field in self._declared_fields.keys():
+        if not field in data:
+            data[field] = marshmallow.missing
     obj = self.__model_class__(__post_load__=True, **data)
     obj.__schema__ = self
     return obj

--- a/marshmallow_objects/models.py
+++ b/marshmallow_objects/models.py
@@ -23,7 +23,7 @@ MM2 = marshmallow.__version__.startswith('2')
 @marshmallow.post_load
 def __make_object__(self, data):
     for field in self._declared_fields.keys():
-        if not field in data:
+        if field not in data:
             data[field] = marshmallow.missing
     obj = self.__model_class__(__post_load__=True, **data)
     obj.__schema__ = self


### PR DESCRIPTION
Add marshmallow feature of excluding missing fields in serialized output.

This is non-backward compatible change, requiring users to set `default=None` to preserve behaviour of `dump` in previous `marshmallow_objects` version, which sets missing fields to `None`.