### PR TITLE
Test against versions 2.16.2 and 3.0.0.b19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ python:
   - "2.7"
 
 env:
-  - MARSHMALLOW_VERSION=2.16.1
-  - MARSHMALLOW_VERSION=3.0.0b18
+  - MARSHMALLOW_VERSION=2.16.2
+  - MARSHMALLOW_VERSION=3.0.0b19
 
 install:
   - pip install marshmallow==$MARSHMALLOW_VERSION

--- a/marshmallow_objects/models.py
+++ b/marshmallow_objects/models.py
@@ -87,10 +87,11 @@ class NestedModel(fields.Nested):
     def __init__(self, nested, **kwargs):
         super(NestedModel, self).__init__(nested.__schema_class__, **kwargs)
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, data, **kwargs):
         if isinstance(value, Model):
             return value
-        return super(NestedModel, self)._deserialize(value, attr, data)
+        return super(NestedModel, self)._deserialize(value, attr, data,
+                                                     **kwargs)
 
 
 class Model(compat.with_metaclass(ModelMeta)):


### PR DESCRIPTION
Add `**kwargs` argument the `_deserialize` function of the NestedModel class.