### PR TITLE
Implement a custom __deepcopy__ magic method to sidestep the unpickleable thread lock.

### DIFF
--- a/marshmallow_objects/models.py
+++ b/marshmallow_objects/models.py
@@ -238,7 +238,14 @@ class Model(compat.with_metaclass(ModelMeta)):
         return schema.validate(data, many=many, partial=partial)
 
     def __copy__(self):
+        """A magic method to implement shallow copy behavior."""
         return self.__class__.load(self.dump(), context=self.context)
+
+    def __deepcopy__(self, memo):
+        """A magic method to implement deep copy behavior."""
+        obj = self.__class__.load(self.dump(), context=self.context.copy())
+        memo[id(obj)] = obj
+        return obj
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -175,8 +175,10 @@ class TestModel(unittest.TestCase):
     def test_copy(self):
         a1 = A(test_field='1')
         a2 = copy.copy(a1)
-        self.assertNotEqual(id(a1), id(a2))
-        self.assertEqual(a1, a2)
+        a3 = copy.deepcopy(a2)
+        self.assertIs(a1.test_field, a2.test_field, a3.test_field)
+        self.assertNotEqual(id(a1), id(a2), id(a3))
+        self.assertEqual(a1, a2, a3)
 
     def test_repr(self):
         a = A()


### PR DESCRIPTION
Possible solution to #51 

Tests appear to pass,

```
>>> from marshmallow_objects.models import Model, fields
>>> class M(Model):
...     my_int = fields.Int()
...
>>> m = M(my_int=1)
>>> m
M(**{'my_int': 1})
>>> import copy
>>> m2 = copy.deepcopy(m)
>>> m2 is m
False
>>> m.__dump_lock__
<unlocked _thread.RLock object owner=0 count=0 at 0x7f93c9a5a3c0>
>>> m2.__dump_lock__
<unlocked _thread.RLock object owner=0 count=0 at 0x7f93c9a5a780>
>>> m.dump()
{'my_int': 1}
>>> m2.dump()
{'my_int': 1}
```

and with threads

```
>>> with ThreadPoolExecutor(10) as exe:
...     exe.map(lambda x:print(x.dump()), [copy.deepcopy(m) for _ in range(9)])
...
{'my_int': 1}
{'my_int': 1}
{'my_int': 1}
{'my_int': 1}
{'my_int': 1}
{'my_int': 1}
{'my_int': 1}
{'my_int': 1}
{'my_int': 1}
```